### PR TITLE
fix: Support for KaiOS 2.5 #83

### DIFF
--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -29,7 +29,7 @@ const EasySpeech = {};
  * on what's available with window as priority, since Browsers are main target.
  * @private
  */
-const scope = globalThis;
+const scope = typeof globalThis === 'undefined' ? window : globalThis;
 
 /**
  * @private
@@ -135,7 +135,7 @@ const detectFeatures = () => {
 
   // not published to the outside
   patches.isAndroid = isAndroid();
-  patches.isFirefox = isFirefox();
+  patches.isFirefox = isFirefox() || isKaiOS();
   patches.isSafari = isSafari();
 
   debug(`is android: ${!!patches.isAndroid}`);
@@ -155,6 +155,10 @@ const isAndroid = () => {
 };
 
 /** @private **/
+const isKaiOS = () => {
+  const ua = (scope.navigator || {}).userAgent || '';
+  return /kaios/i.test(ua)
+};
 const isFirefox = () => typeof scope.InstallTrigger !== 'undefined';
 const isSafari = () => typeof scope.GestureEvent !== 'undefined';
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const EasySpeech = {}
  * on what's available with window as priority, since Browsers are main target.
  * @private
  */
-const scope = globalThis
+const scope = typeof globalThis === 'undefined' ? window : globalThis
 
 /**
  * @private
@@ -135,7 +135,7 @@ const detectFeatures = () => {
 
   // not published to the outside
   patches.isAndroid = isAndroid()
-  patches.isFirefox = isFirefox()
+  patches.isFirefox = isFirefox() || isKaiOS()
   patches.isSafari = isSafari()
 
   debug(`is android: ${!!patches.isAndroid}`)
@@ -155,6 +155,10 @@ const isAndroid = () => {
 }
 
 /** @private **/
+const isKaiOS = () => {
+  const ua = (scope.navigator || {}).userAgent || ''
+  return /kaios/i.test(ua)
+}
 const isFirefox = () => typeof scope.InstallTrigger !== 'undefined'
 const isSafari = () => typeof scope.GestureEvent !== 'undefined'
 


### PR DESCRIPTION
Two changes were necessary to run easy-speech on KaiOS:

1. An additional KaiOS check is added, based on the user navigator, this if it succeeds, it is treated as a isFirefox. The original test fails, since KaiOS (2.5) uses version 49, an older one. However, the TTS functionality is the same.
2. `globalThis` is not defined in KaiOS 2.5, which causes a ReferenceError and thus, the entire lib to fail. That is why an additional check was added.

However, the resulting output still needs to be transpiled with babel, since the KaiOS browser does not support es6 syntax.